### PR TITLE
Add first fall 2016 talks

### DIFF
--- a/events/_posts/2016-08-25-Sasaki.md
+++ b/events/_posts/2016-08-25-Sasaki.md
@@ -1,0 +1,15 @@
+---
+layout: event
+categories: talk
+name: Shinji Sasaki
+institution: University of Toronto
+title: An introduction to the exact WKB analysis, with emphasis on its fundamental aspects
+date: "2016-08-25 11:10"
+location: "Fields Institute, room 210"
+videourl:
+---
+Abstract: In this talk, I am going to give an introduction to the exact WKB analysis, that is, WKB analysis based on the Borel resummation.
+
+I start with review of basic notions and facts (such as Stokes geometry, Borel summability of WKB solutions etc.) for the prototypical equation namely second order linear ODE with a small (or large) parameter. Then I introduce WKB-theoretic transformations to canonical equations (Airy equation, Weber equation etc.) by Aoki-Kawai-Takei, explain their consequence and Borel summability.
+
+I will also give an overview of the exact WKB analysis of higher order equations.

--- a/events/_posts/2016-09-01-Matviichuk.md
+++ b/events/_posts/2016-09-01-Matviichuk.md
@@ -1,0 +1,11 @@
+---
+layout: event
+categories: talk
+name: Mykola Matviichuk
+institution: University of Toronto
+title: Deformation theory of Dirac structures via $$L_\infty$$ algebras
+date: "2016-09-01 11:10"
+location: "Fields Institute, room 210"
+videourl:
+---
+Abstract: Dirac structure is a lagrangian subalgebroid in a Lie bialgebroid. For a Dirac structure we construct a canonical isomorphism class of $$L_\infty$$ algebras, which controls the deformation theory of the Dirac structure. The results have applications to the deformation theory of holomorphic Poisson structures.


### PR DESCRIPTION
I've made event pages for the first two talks of fall 2016. Assuming I've formatted them right, I guess we should merge them in so they show up on the web site?
